### PR TITLE
Explicitly disabling IPv6 - no support by Nethserver 7.x

### DIFF
--- a/root/etc/e-smith/templates/etc/unbound/unbound.conf/40unbound_conf
+++ b/root/etc/e-smith/templates/etc/unbound/unbound.conf/40unbound_conf
@@ -156,10 +156,10 @@ server:
 	# infra-cache-numhosts: 10000
 
 	# Enable IPv4, "yes" or "no".
-	# do-ip4: yes
+	do-ip4: yes
 
 	# Enable IPv6, "yes" or "no".
-	# do-ip6: yes
+	do-ip6: no
 
 	# Enable UDP, "yes" or "no".
 	# NOTE: if setting up an unbound on tls443 for public use, you might want to


### PR DESCRIPTION
Nethserver officially does not support IPv6 for various reasons. This lack of support particularly comes from the firewall, but also from dns/ip blacklisting, fail2ban, etc.
With IPv6 enabled in the network stack, however, this leads to an unprotected IPv6 shadow network, depending on WAN routing,
While Nethserver does NOT support ipv6, I've disabled it through sysctl. As a result, the unbound service refuses to start.